### PR TITLE
no mencionar "profundas"

### DIFF
--- a/src/main.typ
+++ b/src/main.typ
@@ -227,13 +227,6 @@ activación no lineal adecuada (como la sigmoide), puede aproximar cualquier
 función continua definida sobre un conjunto compacto de $RR^n$, con suficiente
 número de neuronas.
 
-
-== Redes neuronales Profundas
-
-Las redes neuronales actuales consisten de una larga composición de funciones,
-incluyendo perceptrones multicapa, es importante notar que la teoría indica que
-un perceptrón con tres capas es suficiente.
-
 == Entrenamiento
 
 === Aprendizaje supervisado


### PR DESCRIPTION
No hay motivo para tener ese disclaimer en la sección de redes neuronales profundas si no hay sección de redes neuronales profundas :ok_hand:
+ Ahorramos tiempo